### PR TITLE
Correct invalid keywords.txt KEYWORD_TOKENTYPE

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,6 +1,6 @@
-changeI2CAddress	KWYWORD2
-getChannelState	KWYWORD2
-getFirmwareVersion	KWYWORD2
-channelCtrl	KWYWORD2
-turn_on_channel	KWYWORD2
-turn_off_channel	KWYWORD2
+changeI2CAddress	KEYWORD2
+getChannelState	KEYWORD2
+getFirmwareVersion	KEYWORD2
+channelCtrl	KEYWORD2
+turn_on_channel	KEYWORD2
+turn_off_channel	KEYWORD2


### PR DESCRIPTION
Use of an invalid KEYWORD_TOKENTYPE value in keywords.txt causes the keyword to be colored by the default editor.function.style (as used by KEYWORD2, KEYWORD3, LITERAL2) in Arduino IDE 1.6.5 and newer. On Arduino IDE 1.6.4 and older this will cause the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype